### PR TITLE
34 - Fix (WrongFormatException.java): add serialVersionUID

### DIFF
--- a/src/errors/WrongFormatException.java
+++ b/src/errors/WrongFormatException.java
@@ -3,11 +3,14 @@ package errors;
 import java.io.IOException;
 
 public class WrongFormatException extends IOException{
-	    public WrongFormatException(String errorMessage) {
-	        super(errorMessage);
-	    }
-	    
-	    public WrongFormatException(String errorMessage, Throwable errorCause) {
-	        super(errorMessage, errorCause);
-	    }
+	/** serial version UID */
+	private static final long serialVersionUID = 1L;
+
+	public WrongFormatException(String errorMessage) {
+		super(errorMessage);
+	}
+
+	public WrongFormatException(String errorMessage, Throwable errorCause) {
+		super(errorMessage, errorCause);
+	}
 }

--- a/src/errors/WrongFormatException.java
+++ b/src/errors/WrongFormatException.java
@@ -3,7 +3,10 @@ package errors;
 import java.io.IOException;
 
 public class WrongFormatException extends IOException{
-	    public WrongFormatException(String errorMessage) {
+	    /** serial version UID */
+	private static final long serialVersionUID = 1L;
+
+		public WrongFormatException(String errorMessage) {
 	        super(errorMessage);
 	    }
 	    


### PR DESCRIPTION
Aggiunto, come richiesto dal compilatore, il serial ID. La classe WrongFormatException.java estende IOException, sottoclasse di Throwable, che a sua volta implementa l'interfaccia Serializable, quindi ci viene chiesto di definire l'attributo serialVersionUID. E' necesssario quando la classe e' usata in ambienti distribuiti, ossia gli oggetti della classe devono esser usati in virtual machine diverse. In questo caso dovrebbe esserci una copia della classe serializzabile su macchine diverse, e l'attributo garantisce la compatibilita' delle 2 versioni. Altrimenti la lettura dell'oggetto serializzabile potrebbe fallire e successivamente lanciata una InvalidClassException.

Close #34